### PR TITLE
Update websocket.md with fix for defCrsrAttr issue

### DIFF
--- a/docs/_docs/servers/loginservers/websocket.md
+++ b/docs/_docs/servers/loginservers/websocket.md
@@ -90,7 +90,7 @@ webserver, and unpack it to a temporary directory.
         xScale: 1,
         initStr: "",
         defPageAttr: 0x1010,
-        defCrsrAttr: 0x0207,
+        defCrsrAttr: ['thick', 'horizontal'],
         defCellAttr: 0x0007,
         telnet: 1,
         autoConnect: 0


### PR DESCRIPTION
Documentation is wrong when it comes to configuring the VTX client. This cause me a bit of headache and googling, so would be nice to have the documentation updated.

defCrsrAttr is an array not a number and it prevents the VTX client from connecting.

Ref: 
https://github.com/NuSkooler/enigma-bbs/issues/500